### PR TITLE
Support GraphQL heredocs

### DIFF
--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -2324,6 +2324,64 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>(?=(?&gt;&lt;&lt;-("?)((?:[_\w]+_|)GRAPHQL)\b\1))</string>
+			<key>comment</key>
+			<string>Heredoc with embedded GraphQL</string>
+			<key>end</key>
+			<string>(?!\G)</string>
+			<key>name</key>
+			<string>meta.embedded.block.graphql</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>(?&gt;&lt;&lt;-("?)((?:[_\w]+_|)GRAPHQL)\b\1)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.string.begin.ruby</string>
+						</dict>
+					</dict>
+					<key>contentName</key>
+					<string>source.graphql</string>
+					<key>end</key>
+					<string>\s*\2$\n?</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.string.end.ruby</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>string.unquoted.heredoc.ruby</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#heredoc</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#interpolated_ruby</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>source.graphql</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#escaped_char</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>(?&gt;[=,]\s*&lt;&lt;(\w+))</string>
 			<key>beginCaptures</key>
 			<dict>


### PR DESCRIPTION
This pull request adds a rule to the Ruby syntax for GraphQL syntax highlighting within `<<-GRAPHQL` heredocs, similar to the existing rules for other languages such as SQL and HTML.

cc @aroben @gjtorikian @kdaigle
